### PR TITLE
Disabled batching in all shaders

### DIFF
--- a/Toocanzs/Vertical Billboard/VerticalBillboard Cutout.shader
+++ b/Toocanzs/Vertical Billboard/VerticalBillboard Cutout.shader
@@ -5,9 +5,13 @@
 		_MainTex ("Texture", 2D) = "white" {}
 		_Cutout("Cutout Threshold", Range(0,1)) = 0
 	}
-		SubShader
+	SubShader
 	{
-		Tags { "RenderType" = "Opaque"}
+		Tags
+		{
+			"RenderType" = "Opaque"
+			"DisableBatching" = "True"
+		}
 		Pass
 		{
 			CGPROGRAM

--- a/Toocanzs/Vertical Billboard/VerticalBillboard Opaque.shader
+++ b/Toocanzs/Vertical Billboard/VerticalBillboard Opaque.shader
@@ -6,7 +6,11 @@
 	}
 	SubShader
 	{
-		Tags { "RenderType" = "Opaque"}
+		Tags
+		{
+			"RenderType" = "Opaque"
+			"DisableBatching" = "True"
+		}
 		Pass
 		{
 			CGPROGRAM

--- a/Toocanzs/Vertical Billboard/VerticalBillboard Transparent.shader
+++ b/Toocanzs/Vertical Billboard/VerticalBillboard Transparent.shader
@@ -6,7 +6,12 @@
 	}
 	SubShader
 	{
-		Tags { "RenderType" = "Opaque" "Queue" = "Transparent"}
+		Tags
+		{
+			"Queue" = "Transparent"
+			"RenderType" = "Opaque"
+			"DisableBatching" = "True"
+		}
 		ZWrite Off
 		Blend SrcAlpha OneMinusSrcAlpha
 		Pass


### PR DESCRIPTION
Individual object pivots are lost when batching as the vertices are transformed to absolute world space.